### PR TITLE
Bump Protobuf version to bump GRPC version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'google-protobuf', '~> 3.19.6'
+gem 'google-protobuf', '~> 3.19'
 
 gemspec

--- a/examples/Gemfile
+++ b/examples/Gemfile
@@ -4,6 +4,6 @@ gem 'temporal-ruby', path: '../'
 
 gem 'dry-types', '>= 1.7.2'
 gem 'dry-struct', '~> 1.6.0'
-gem 'google-protobuf', '~> 3.19.6'
+gem 'google-protobuf', '~> 3.19'
 
 gem 'rspec', group: :test


### PR DESCRIPTION
https://github.com/coinbase/temporal-ruby/pull/310

Relaxing our protobuf version to MAJOR.MINOR so that we can get `grpc` newer than `1.48.0`, which does not compile on M3 macs. 